### PR TITLE
CI: Configure publish workflow to trigger on push to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Release
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   publish:


### PR DESCRIPTION
This commit updates the `.github/workflows/publish.yml` file.

- Changed the workflow trigger from `workflow_dispatch` to `push` on the `master` branch.