### PR TITLE
Refactor: Update publishing and documentation plugins

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,8 @@ multiplatform-markdown       = "0.26.0"
 uiAndroid                    = "1.7.8"
 foundationLayoutAndroid      = "1.7.8"
 uiTextAndroid                = "1.7.8"
-gradlePublish                = "1.3.0"
+gradlePublish                = "0.29.0"
+dokka                        = "1.9.20"
 
 [libraries]
 androidx-activity-compose            = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
@@ -34,4 +35,5 @@ androidLibrary         = { id = "com.android.library", version.ref = "agp" }
 composeMultiplatform   = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
 composeCompiler        = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform    = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-gradle-publish         = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradlePublish" }
+gradle-publish         = { id = "com.vanniktech.maven.publish", version.ref = "gradlePublish" }
+dokka                  = { id = "org.jetbrains.dokka", version.ref = "dokka" }

--- a/material-theme-kit/build.gradle.kts
+++ b/material-theme-kit/build.gradle.kts
@@ -1,5 +1,6 @@
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class)
 
+import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -10,8 +11,8 @@ plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
-    id("maven-publish")
-    id("signing")
+    alias(libs.plugins.gradle.publish)
+    alias(libs.plugins.dokka)
 }
 
 kotlin {
@@ -89,37 +90,36 @@ dependencies {
     debugImplementation(compose.uiTooling)
 }
 
-publishing {
-    publications.withType<MavenPublication> {
-        pom {
-            name.set("MaterializeKMP")
-            description.set("Dynamic Theme Manager: Essential Kotlin Multiplatform Library for Seamless Theming Across All Platforms")
-            inceptionYear.set("2025")
-            url.set("https://github.com/tarifchakder/MaterializeKMP")
-            licenses {
-                license {
-                    name.set("MIT")
-                    url.set("https://opensource.org/licenses/MIT")
-                }
-            }
-            developers {
-                developer {
-                    id.set("tarif")
-                    name.set("Tarif Chakder")
-                    email.set("tarifchakder@outlook.com")
-                }
-            }
-            scm {
-                url.set("https://github.com/tarifchakder/MaterializeKMP")
+mavenPublishing {
+    coordinates(
+        groupId = "io.github.tarifchakder.materializekmp",
+        artifactId = "material-theme",
+        version = "1.0.6"
+    )
+
+    pom {
+        name.set("MaterializeKMP")
+        description.set("Dynamic Theme Manager: Essential Kotlin Multiplatform Library for Seamless Theming Across All Platforms")
+        inceptionYear.set("2025")
+        url.set("https://github.com/tarifchakder/MaterializeKMP")
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://opensource.org/licenses/MIT")
             }
         }
+        developers {
+            developer {
+                id.set("tarif")
+                name.set("Tarif Chakder")
+                email.set("tarifchakder@outlook.com")
+            }
+        }
+        scm {
+            url.set("https://github.com/tarifchakder/MaterializeKMP")
+        }
     }
-}
 
-signing {
-    useInMemoryPgpKeys(
-        System.getenv("GPG_PRIVATE_KEY"),
-        System.getenv("GPG_PASSPHRASE")
-    )
-    sign(publishing.publications)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
+    signAllPublications()
 }


### PR DESCRIPTION
This commit updates the `material-theme-kit/build.gradle.kts` and `gradle/libs.versions.toml` files.

- In `material-theme-kit/build.gradle.kts`:
    - Replaced `maven-publish` and `signing` plugins with `com.vanniktech.maven.publish` (aliased as `libs.plugins.gradle.publish`) and `org.jetbrains.dokka` (aliased as `libs.plugins.dokka`).
    - Migrated from the `publishing` block to the `mavenPublishing` block provided by the `com.vanniktech.maven.publish` plugin.
        - Configured coordinates with `groupId = "io.github.tarifchakder.materializekmp"`, `artifactId = "material-theme"`, and `version = "1.0.6"`.
        - The POM configuration remains largely the same. - Replaced manual GPG key signing with `publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)` and `signAllPublications()`.
- In `gradle/libs.versions.toml`:
    - Updated the `gradlePublish` plugin version from `1.3.0` to `0.29.0` and changed its ID from `io.github.gradle-nexus.publish-plugin` to `com.vanniktech.maven.publish`.
    - Added the `dokka` plugin with version `1.9.20` and ID `org.jetbrains.dokka`.